### PR TITLE
refactor: pass execution context explicitly

### DIFF
--- a/lua/command/actions/prompt.lua
+++ b/lua/command/actions/prompt.lua
@@ -1,7 +1,9 @@
 local config = require('command.config')
+---@type CommandExecutor
 local executor = require('command.execution.executor')
 local history = require('command.history')
 local notify = require('command.util.notify')
+---@type CommandPrompt
 local prompt = require('command.ui.prompt')
 local ghost_text = require('command.ui.ghost_text')
 local session = require('command.session')
@@ -19,6 +21,7 @@ function M.enter()
     ghost_text.clear(window.buf)
 
     local ran = executor.run(cmd, {
+        context = window.opts and window.opts.context or nil,
         before_execute = function()
             history.reset_index()
             prompt.close()

--- a/lua/command/api.lua
+++ b/lua/command/api.lua
@@ -2,6 +2,7 @@ local config = require('command.config')
 local executor = require('command.execution.executor')
 local history = require('command.history')
 local notify = require('command.util.notify')
+---@type CommandPrompt
 local prompt = require('command.ui.prompt')
 local prompt_actions = require('command.actions.prompt')
 local selection = require('command.util.selection')
@@ -16,13 +17,18 @@ local function prepare_context()
 end
 
 function M.execute()
-    prepare_context()
+    local context = prepare_context()
 
-    if prompt.focus() then
+    if prompt.focus(context) then
         return
     end
 
-    local result = prompt.create(config.values.ui.prompt, prompt_actions)
+    ---@type CommandPromptCreateOpts
+    local prompt_opts = vim.tbl_extend('force', {}, config.values.ui.prompt or {}, {
+        context = context,
+    })
+
+    local result = prompt.create(prompt_opts, prompt_actions)
     if not result then
         notify.error('Could not create the prompt window')
         return
@@ -39,11 +45,11 @@ function M.execute_selection()
         return
     end
 
-    executor.run(selected)
+    executor.run(selected, { context = context })
 end
 
 function M.execute_last()
-    prepare_context()
+    local context = prepare_context()
 
     if not session.has_run() then
         notify.error('Use first `:CommandExecute`')
@@ -56,7 +62,10 @@ function M.execute_last()
         return
     end
 
-    executor.run(last, { record_history = false })
+    executor.run(last, {
+        context = context,
+        record_history = false,
+    })
 end
 
 return M

--- a/lua/command/execution/executor.lua
+++ b/lua/command/execution/executor.lua
@@ -7,13 +7,23 @@ local terminal = require('command.ui.terminal')
 local terminal_actions = require('command.actions.terminal')
 local validation = require('command.execution.validation')
 
+---@class CommandRunOpts
+---@field context ExecutionContext|nil Context used for expansion and cwd resolution
+---@field before_execute fun()|nil Callback run before creating the terminal
+---@field record_history boolean|nil When false, skip adding the command to history
+
+---@class CommandExecutor
+---@field run fun(cmd: string, opts: CommandRunOpts|nil): boolean
+
+---@type CommandExecutor
 local M = {}
 
 ---@param cmd string
----@param opts table|nil
+---@param opts CommandRunOpts|nil
 ---@return boolean
 function M.run(cmd, opts)
-    opts = opts or {}
+    ---@type CommandRunOpts
+    local run_opts = opts or {}
 
     local normalized = (cmd or ''):gsub('^%s+', ''):gsub('%s+$', '')
     if normalized == '' then
@@ -21,28 +31,37 @@ function M.run(cmd, opts)
         return false
     end
 
-    local context = opts.context or session.get_context()
+    local context = run_opts.context
+    if not context then
+        notify.error('Could not resolve execution context')
+        return false
+    end
+
     local expanded = expansion.expand(normalized, context)
 
     if not validation.validate_command(expanded) then
         return false
     end
 
-    if opts.before_execute then
-        opts.before_execute()
+    if run_opts.before_execute then
+        run_opts.before_execute()
     end
 
-    if opts.record_history ~= false then
+    if run_opts.record_history ~= false then
         history.add(normalized)
     end
 
-    local terminal_window = terminal.create(config.values.ui.terminal, terminal_actions)
+    local terminal_opts = vim.tbl_extend('force', {}, config.values.ui.terminal or {}, {
+        context = context,
+    })
+
+    local terminal_window = terminal.create(terminal_opts, terminal_actions)
     if not terminal_window then
         notify.error('Could not create terminal window')
         return false
     end
 
-    if not terminal.send_command(expanded) then
+    if not terminal.send_command(expanded, context) then
         notify.error('Could not create terminal job')
         return false
     end

--- a/lua/command/execution/expansion.lua
+++ b/lua/command/execution/expansion.lua
@@ -32,7 +32,7 @@ function M.expand(cmd, context)
             return tostring(context.cursor[2] + 1)
         end,
         cwd = function()
-            return session.get_resolved_cwd()
+            return session.get_resolved_cwd(context)
         end,
         selection = function()
             return selection.get_visual_selection(context.buf)

--- a/lua/command/history/picker.lua
+++ b/lua/command/history/picker.lua
@@ -28,6 +28,7 @@ function M.search(entries, callback)
         end)
     end
 
+    ---@type CommandPromptWindow|nil
     local prompt_window = session.get_window('prompt')
     local fzf_opts = {
         prompt = 'History> ',

--- a/lua/command/session.lua
+++ b/lua/command/session.lua
@@ -1,8 +1,13 @@
+---@class CommandWindowOpts
+---@field context ExecutionContext|nil Source context associated with a tracked UI window
+
 ---@class Window
 ---@field name string Window identifier
 ---@field buf integer Buffer handle
 ---@field win integer Window handle
----@field opts table Window options
+---@field opts CommandWindowOpts|nil Window options
+---@field job_id integer|nil Terminal job handle
+---@field exit_code integer|nil Terminal job exit code
 
 ---@class ExecutionContext
 ---@field buf integer Buffer handle
@@ -10,12 +15,15 @@
 ---@field cursor integer[] Cursor position {line, col}
 ---@field mode string Current mode
 
+---@class CommandUnregisterWindowOpts
+---@field close boolean|nil Close the tracked window
+---@field delete_buffer boolean|nil Delete the tracked buffer
+
 local notify = require('command.util.notify')
 
 local M = {
     _windows = {},
     _jobs = {},
-    _context = nil, ---@type ExecutionContext|nil
     _cwd_mode = nil, ---@type string|nil
     _has_run = false,
 }
@@ -30,27 +38,39 @@ local function find_window(name)
     return nil, nil
 end
 
+---@param buf integer
+---@param win integer
+---@return ExecutionContext|nil
+local function find_window_context(buf, win)
+    for _, window in ipairs(M._windows) do
+        if window.buf == buf or window.win == win then
+            local opts = window.opts or {}
+            if opts.context then
+                return opts.context
+            end
+        end
+    end
+
+    return nil
+end
+
 ---@return ExecutionContext
 function M.capture_context()
+    local buf = vim.api.nvim_get_current_buf()
+    local win = vim.api.nvim_get_current_win()
+    local window_context = find_window_context(buf, win)
+    if window_context then
+        return window_context
+    end
+
     local ctx = {
-        buf = vim.api.nvim_get_current_buf(),
-        win = vim.api.nvim_get_current_win(),
+        buf = buf,
+        win = win,
         cursor = vim.api.nvim_win_get_cursor(0),
         mode = vim.api.nvim_get_mode().mode,
     }
 
-    M.set_context(ctx)
     return ctx
-end
-
----@param ctx ExecutionContext
-function M.set_context(ctx)
-    M._context = ctx
-end
-
----@return ExecutionContext|nil
-function M.get_context()
-    return M._context
 end
 
 ---@param mode string
@@ -63,10 +83,11 @@ function M.get_cwd_mode()
     return M._cwd_mode
 end
 
+---@param context ExecutionContext|nil
 ---@return string
-function M.get_resolved_cwd()
-    if M._cwd_mode == 'buffer' and M._context and M._context.buf then
-        local file = vim.api.nvim_buf_get_name(M._context.buf)
+function M.get_resolved_cwd(context)
+    if M._cwd_mode == 'buffer' and context and context.buf then
+        local file = vim.api.nvim_buf_get_name(context.buf)
         if file ~= '' then
             local dir = vim.fn.fnamemodify(file, ':h')
             if vim.fn.isdirectory(dir) == 1 then
@@ -110,10 +131,11 @@ function M.get_window(name)
 end
 
 ---@param name string
----@param opts table|nil
+---@param opts CommandUnregisterWindowOpts|nil
 ---@return Window|nil
 function M.unregister_window(name, opts)
-    opts = opts or {}
+    ---@type CommandUnregisterWindowOpts
+    local window_opts = opts or {}
 
     local idx, window = find_window(name)
     if not idx or not window then
@@ -122,11 +144,11 @@ function M.unregister_window(name, opts)
 
     table.remove(M._windows, idx)
 
-    if opts.close ~= false and window.win and vim.api.nvim_win_is_valid(window.win) then
+    if window_opts.close ~= false and window.win and vim.api.nvim_win_is_valid(window.win) then
         pcall(vim.api.nvim_win_close, window.win, true)
     end
 
-    if opts.delete_buffer ~= false and window.buf and vim.api.nvim_buf_is_valid(window.buf) then
+    if window_opts.delete_buffer ~= false and window.buf and vim.api.nvim_buf_is_valid(window.buf) then
         pcall(vim.api.nvim_buf_delete, window.buf, { force = true })
     end
 
@@ -162,7 +184,6 @@ function M.cleanup(force)
 
     M._windows = {}
     M._jobs = {}
-    M._context = nil
     M._cwd_mode = nil
     M._has_run = false
 

--- a/lua/command/ui/prompt.lua
+++ b/lua/command/ui/prompt.lua
@@ -2,13 +2,37 @@ local config = require('command.config')
 local ghost_text = require('command.ui.ghost_text')
 local session = require('command.session')
 
+---@class CommandPromptCreateOpts: CommandConfigPromptOpts
+---@field context ExecutionContext|nil Source context used by prompt actions and title rendering
+
+---@class CommandPromptWindowOpts: CommandWindowOpts
+---@field width integer Prompt window width
+---@field height integer Prompt window height
+---@field max_width integer Maximum prompt width used for layout
+---@field context ExecutionContext|nil Source context associated with the prompt
+
+---@class CommandPromptWindow: Window
+---@field name 'prompt'
+---@field opts CommandPromptWindowOpts
+
+---@class CommandPrompt
+---@field create fun(opts: CommandPromptCreateOpts|nil, actions: table): CommandPromptWindow|nil
+---@field get fun(): CommandPromptWindow|nil
+---@field focus fun(context: ExecutionContext|nil): boolean
+---@field update_title fun()
+---@field close fun()
+---@field set_text fun(command: string)
+---@field get_text fun(): string
+
+---@type CommandPrompt
 local M = {}
 
 local WINDOW_NAME = 'prompt'
 local PROMPT_HEIGHT = 1
 
-local function build_title()
-    local cwd = vim.fn.fnamemodify(session.get_resolved_cwd(), ':~')
+---@param context ExecutionContext|nil
+local function build_title(context)
+    local cwd = vim.fn.fnamemodify(session.get_resolved_cwd(context), ':~')
     return ' ' .. cwd .. ' '
 end
 
@@ -46,11 +70,12 @@ local function attach_default_keymaps(buf, actions)
     end
 end
 
----@param opts table|nil
+---@param opts CommandPromptCreateOpts|nil
 ---@param actions table
----@return table|nil
+---@return CommandPromptWindow|nil
 function M.create(opts, actions)
-    opts = opts or {}
+    ---@type CommandPromptCreateOpts
+    local create_opts = opts or {}
 
     if M.get() then
         M.close()
@@ -60,14 +85,14 @@ function M.create(opts, actions)
     vim.api.nvim_set_option_value('bufhidden', 'wipe', { buf = buf })
     vim.api.nvim_set_option_value('swapfile', false, { buf = buf })
 
-    local max_width = opts.max_width or config.values.ui.prompt.max_width or 40
+    local max_width = create_opts.max_width or config.values.ui.prompt.max_width or 40
     local width = math.max(max_width, math.floor(vim.o.columns * 0.5))
     local height = PROMPT_HEIGHT
     local row = math.floor((vim.o.lines - height) / 2 - 1)
     local col = math.floor((vim.o.columns - width) / 2)
 
     local win = vim.api.nvim_open_win(buf, true, {
-        title = build_title(),
+        title = build_title(create_opts.context),
         title_pos = 'right',
         relative = 'editor',
         width = width,
@@ -85,7 +110,8 @@ function M.create(opts, actions)
 
     vim.api.nvim_set_option_value('wrap', false, { win = win })
 
-    session.register_window({
+    ---@type CommandPromptWindow
+    local window = {
         name = WINDOW_NAME,
         buf = buf,
         win = win,
@@ -93,8 +119,11 @@ function M.create(opts, actions)
             width = width,
             height = height,
             max_width = max_width,
+            context = create_opts.context,
         },
-    })
+    }
+
+    session.register_window(window)
 
     attach_default_keymaps(buf, actions)
 
@@ -102,17 +131,26 @@ function M.create(opts, actions)
         ghost_text.attach(buf)
     end
 
-    return { buf = buf, win = win }
+    return window
 end
 
----@return table|nil
+---@return CommandPromptWindow|nil
 function M.get()
-    return session.get_window(WINDOW_NAME)
+    ---@type CommandPromptWindow|nil
+    local window = session.get_window(WINDOW_NAME)
+    return window
 end
 
-function M.focus()
+---@param context ExecutionContext|nil
+function M.focus(context)
     local window = M.get()
     if window and vim.api.nvim_win_is_valid(window.win) then
+        if context then
+            window.opts = window.opts or {}
+            window.opts.context = context
+            M.update_title()
+        end
+
         vim.api.nvim_set_current_win(window.win)
         vim.cmd('startinsert')
         return true
@@ -124,7 +162,8 @@ end
 function M.update_title()
     local window = M.get()
     if window and vim.api.nvim_win_is_valid(window.win) then
-        vim.api.nvim_win_set_config(window.win, { title = build_title() })
+        local context = window.opts and window.opts.context or nil
+        vim.api.nvim_win_set_config(window.win, { title = build_title(context) })
     end
 end
 

--- a/lua/command/ui/terminal.lua
+++ b/lua/command/ui/terminal.lua
@@ -1,6 +1,28 @@
 local config = require('command.config')
 local session = require('command.session')
 
+---@class CommandTerminalCreateOpts: CommandConfigTerminalOpts
+---@field context ExecutionContext|nil Source context used for cwd resolution and terminal reuse
+
+---@class CommandTerminalWindowOpts: CommandWindowOpts
+---@field height number Terminal height used when opening the split
+---@field split string Terminal split direction
+---@field context ExecutionContext|nil Source context associated with the terminal
+
+---@class CommandTerminalWindow: Window
+---@field name 'terminal'
+---@field opts CommandTerminalWindowOpts
+
+---@class CommandTerminal
+---@field create fun(opts: CommandTerminalCreateOpts|nil, actions: table): CommandTerminalWindow|nil
+---@field get fun(): CommandTerminalWindow|nil
+---@field enter_normal_mode fun()
+---@field close fun()
+---@field send_command fun(cmd: string, context: ExecutionContext|nil): boolean
+---@field get_lines fun(): string[]
+---@field get_current_line fun(): string|nil
+
+---@type CommandTerminal
 local M = {}
 
 local WINDOW_NAME = 'terminal'
@@ -24,18 +46,19 @@ local function attach_default_keymaps(buf, actions)
     vim.keymap.set('t', '<C-q>', actions.send_to_quickfix, opts)
 end
 
----@param opts table|nil
+---@param opts CommandTerminalCreateOpts|nil
 ---@param actions table
----@return table|nil
+---@return CommandTerminalWindow|nil
 function M.create(opts, actions)
-    opts = opts or {}
+    ---@type CommandTerminalCreateOpts
+    local create_opts = opts or {}
 
     if M.get() then
         M.close()
     end
 
-    local height = opts.height or config.values.ui.terminal.height or 0.25
-    local split = opts.split or config.values.ui.terminal.split or 'below'
+    local height = create_opts.height or config.values.ui.terminal.height or 0.25
+    local split = create_opts.split or config.values.ui.terminal.split or 'below'
 
     if height < 1 then
         height = math.floor(vim.o.lines * height)
@@ -65,24 +88,30 @@ function M.create(opts, actions)
         return nil
     end
 
-    session.register_window({
+    ---@type CommandTerminalWindow
+    local window = {
         name = WINDOW_NAME,
         buf = buf,
         win = win,
         opts = {
             height = height,
             split = split,
+            context = create_opts.context,
         },
-    })
+    }
+
+    session.register_window(window)
 
     attach_default_keymaps(buf, actions)
 
-    return { buf = buf, win = win }
+    return window
 end
 
----@return table|nil
+---@return CommandTerminalWindow|nil
 function M.get()
-    return session.get_window(WINDOW_NAME)
+    ---@type CommandTerminalWindow|nil
+    local window = session.get_window(WINDOW_NAME)
+    return window
 end
 
 function M.enter_normal_mode()
@@ -109,15 +138,16 @@ function M.close()
 end
 
 ---@param cmd string
+---@param context ExecutionContext|nil
 ---@return boolean
-function M.send_command(cmd)
+function M.send_command(cmd, context)
     local window = M.get()
     if not window or not vim.api.nvim_buf_is_valid(window.buf) then
         return false
     end
 
     local shell = vim.env.SHELL or '/bin/sh'
-    local cwd = session.get_resolved_cwd()
+    local cwd = session.get_resolved_cwd(context or (window.opts and window.opts.context or nil))
 
     local job_id = vim.fn.termopen({ shell, '-ic', cmd }, {
         cwd = cwd,


### PR DESCRIPTION
## Summary
- remove the global session execution context and thread `ExecutionContext` explicitly through the API, prompt, terminal, executor, and expansion flow
- store execution context on tracked prompt and terminal windows so reused UI keeps the original source buffer and cwd behavior
- add concrete Lua option and window types so editor diagnostics show which fields can be passed to internal `opts` tables

## Testing
- `nvim --headless -u test_init.lua \"+lua require('command').setup()\" +q`