### PR TITLE
feat: add terminal reopen to recover accidentally closed terminal windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Neovim plugin that allows you to:
   You can use your shell configuration (e.g., aliases, functions).
 - Keep a history of executed commands and easily access them.
 - Re-execute the last executed command with a single command.
+- Reopen the most recent terminal window if it was closed accidentally and recover its output.
 - Search through the history of executed commands using:
   fzf-lua
 - Use context variables in your commands (e.g., `${file}`, `${line}`, `${selection}`) to reference the current editor state.
@@ -80,7 +81,7 @@ require('command').setup({
             n = {
                 { '<CR>', terminal_act.follow_error },
                 { '<C-q>', terminal_act.send_to_quickfix },
-                { 'q', terminal_act.close },
+                { 'q', terminal_act.hide },
             },
         },
     },
@@ -102,10 +103,17 @@ The codebase is split by responsibility:
 
 # How to use
 
-The plugin provides three commands:
+The plugin provides four commands:
 - `CommandExecute`: Opens a prompt and asks you for the command that you want to execute. Then, a terminal appears and runs the command.
 - `CommandExecuteLast`: Runs the last executed command. `CommandExecute` must have been called previously during the session.
 - `CommandExecuteSelection`: Executes the current text selection as a shell command directly.
+- `CommandReopenTerminal`: Reopens the most recent terminal buffer if it is still available.
+
+### Terminal Recovery
+
+If you close the terminal window accidentally, use `:CommandReopenTerminal` to restore the same terminal buffer with its existing output.
+
+The default `q` mapping hides the terminal window so it can be reopened later. The saved terminal is replaced the next time you run a new command.
 
 ### Working Directory
 

--- a/lua/command/actions/terminal.lua
+++ b/lua/command/actions/terminal.lua
@@ -8,6 +8,10 @@ function M.close()
     terminal.close()
 end
 
+function M.hide()
+    terminal.hide()
+end
+
 function M.follow_error()
     local line = terminal.get_current_line()
     if not line then

--- a/lua/command/api.lua
+++ b/lua/command/api.lua
@@ -7,6 +7,8 @@ local prompt = require('command.ui.prompt')
 local prompt_actions = require('command.actions.prompt')
 local selection = require('command.util.selection')
 local session = require('command.session')
+local terminal = require('command.ui.terminal')
+local terminal_actions = require('command.actions.terminal')
 
 local M = {}
 
@@ -66,6 +68,14 @@ function M.execute_last()
         context = context,
         record_history = false,
     })
+end
+
+function M.reopen_terminal()
+    local terminal_window = terminal.reopen(terminal_actions)
+    if not terminal_window then
+        notify.error('No terminal output available to reopen')
+        return
+    end
 end
 
 return M

--- a/lua/command/init.lua
+++ b/lua/command/init.lua
@@ -48,6 +48,12 @@ function M.execute_selection()
     return api.execute_selection()
 end
 
+---Reopen the last hidden terminal window
+function M.reopen_terminal()
+    ensure_init()
+    return api.reopen_terminal()
+end
+
 ---Teardown and reset the plugin state
 function M.teardown()
     if not M._initialized then

--- a/lua/command/session.lua
+++ b/lua/command/session.lua
@@ -159,6 +159,11 @@ end
 function M.cleanup_window(win_id)
     for idx, window in ipairs(M._windows) do
         if window.win == win_id then
+            if window.name == 'terminal' and window.buf and vim.api.nvim_buf_is_valid(window.buf) then
+                window.win = nil
+                return
+            end
+
             table.remove(M._windows, idx)
             return
         end

--- a/lua/command/ui/terminal.lua
+++ b/lua/command/ui/terminal.lua
@@ -17,7 +17,9 @@ local session = require('command.session')
 ---@field create fun(opts: CommandTerminalCreateOpts|nil, actions: table): CommandTerminalWindow|nil
 ---@field get fun(): CommandTerminalWindow|nil
 ---@field enter_normal_mode fun()
+---@field hide fun()
 ---@field close fun()
+---@field reopen fun(actions: table): CommandTerminalWindow|nil
 ---@field send_command fun(cmd: string, context: ExecutionContext|nil): boolean
 ---@field get_lines fun(): string[]
 ---@field get_current_line fun(): string|nil
@@ -26,6 +28,49 @@ local session = require('command.session')
 local M = {}
 
 local WINDOW_NAME = 'terminal'
+
+---@param opts CommandTerminalCreateOpts|CommandTerminalWindowOpts|nil
+---@return integer, string
+local function resolve_layout(opts)
+    local height = (opts and opts.height) or config.values.ui.terminal.height or 0.25
+    local split = (opts and opts.split) or config.values.ui.terminal.split or 'below'
+
+    if height < 1 then
+        height = math.floor(vim.o.lines * height)
+    end
+
+    height = math.max(height, 3)
+
+    return height, split
+end
+
+---@param buf integer
+---@param opts CommandTerminalCreateOpts|CommandTerminalWindowOpts|nil
+---@return integer|nil, integer, string
+local function open_window(buf, opts)
+    local height, split = resolve_layout(opts)
+
+    if split == 'below' then
+        vim.cmd('botright ' .. height .. ' split')
+    elseif split == 'above' then
+        vim.cmd('topleft ' .. height .. ' split')
+    elseif split == 'right' then
+        vim.cmd('botright ' .. height .. ' vsplit')
+    elseif split == 'left' then
+        vim.cmd('topleft ' .. height .. ' vsplit')
+    else
+        vim.cmd('botright ' .. height .. ' split')
+    end
+
+    local win = vim.api.nvim_get_current_win()
+    if not win or not vim.api.nvim_win_is_valid(win) then
+        return nil, height, split
+    end
+
+    vim.api.nvim_win_set_buf(win, buf)
+
+    return win, height, split
+end
 
 ---@param buf integer
 ---@param actions table
@@ -40,7 +85,7 @@ local function attach_default_keymaps(buf, actions)
     else
         vim.keymap.set('n', '<CR>', actions.follow_error, opts)
         vim.keymap.set('n', '<C-q>', actions.send_to_quickfix, opts)
-        vim.keymap.set('n', 'q', actions.close, opts)
+        vim.keymap.set('n', 'q', actions.hide or actions.close, opts)
     end
 
     vim.keymap.set('t', '<C-q>', actions.send_to_quickfix, opts)
@@ -57,31 +102,10 @@ function M.create(opts, actions)
         M.close()
     end
 
-    local height = create_opts.height or config.values.ui.terminal.height or 0.25
-    local split = create_opts.split or config.values.ui.terminal.split or 'below'
-
-    if height < 1 then
-        height = math.floor(vim.o.lines * height)
-    end
-    height = math.max(height, 3)
-
     local buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_option_value('bufhidden', 'hide', { buf = buf })
 
-    if split == 'below' then
-        vim.cmd('botright ' .. height .. ' split')
-    elseif split == 'above' then
-        vim.cmd('topleft ' .. height .. ' split')
-    elseif split == 'right' then
-        vim.cmd('botright ' .. height .. ' vsplit')
-    elseif split == 'left' then
-        vim.cmd('topleft ' .. height .. ' vsplit')
-    else
-        vim.cmd('botright ' .. height .. ' split')
-    end
-
-    local win = vim.api.nvim_get_current_win()
-    vim.api.nvim_win_set_buf(win, buf)
+    local win, height, split = open_window(buf, create_opts)
 
     if not win or not vim.api.nvim_win_is_valid(win) then
         vim.api.nvim_buf_delete(buf, { force = true })
@@ -107,9 +131,9 @@ function M.create(opts, actions)
     return window
 end
 
----@return CommandTerminalWindow|nil
+---@return Window|nil
 function M.get()
-    ---@type CommandTerminalWindow|nil
+    ---@type Window|nil
     local window = session.get_window(WINDOW_NAME)
     return window
 end
@@ -121,6 +145,15 @@ function M.enter_normal_mode()
             vim.cmd('stopinsert')
         end)
     end
+end
+
+function M.hide()
+    local window = M.get()
+    if not window or not window.win or not vim.api.nvim_win_is_valid(window.win) then
+        return
+    end
+
+    pcall(vim.api.nvim_win_close, window.win, true)
 end
 
 function M.close()
@@ -137,6 +170,40 @@ function M.close()
     session.unregister_window(WINDOW_NAME)
 end
 
+---@param actions table
+---@return CommandTerminalWindow|nil
+function M.reopen(actions)
+    local window = M.get()
+    if not window then
+        return nil
+    end
+
+    if not window.buf or not vim.api.nvim_buf_is_valid(window.buf) then
+        session.unregister_window(WINDOW_NAME, { close = false, delete_buffer = false })
+        return nil
+    end
+
+    if window.win and vim.api.nvim_win_is_valid(window.win) then
+        vim.api.nvim_set_current_win(window.win)
+        return window
+    end
+
+    local win, height, split = open_window(window.buf, window.opts)
+    if not win or not vim.api.nvim_win_is_valid(win) then
+        return nil
+    end
+
+    window.win = win
+    window.opts = window.opts or {}
+    window.opts.height = height
+    window.opts.split = split
+    session.register_window(window)
+
+    attach_default_keymaps(window.buf, actions)
+
+    return window
+end
+
 ---@param cmd string
 ---@param context ExecutionContext|nil
 ---@return boolean
@@ -149,7 +216,8 @@ function M.send_command(cmd, context)
     local shell = vim.env.SHELL or '/bin/sh'
     local cwd = session.get_resolved_cwd(context or (window.opts and window.opts.context or nil))
 
-    local job_id = vim.fn.termopen({ shell, '-ic', cmd }, {
+    local job_id = vim.fn.jobstart({ shell, '-ic', cmd }, {
+        term = true,
         cwd = cwd,
         on_exit = function(jid, exit_code)
             session.remove_job(jid)
@@ -184,6 +252,10 @@ end
 function M.get_current_line()
     local window = M.get()
     if not window or not vim.api.nvim_buf_is_valid(window.buf) then
+        return nil
+    end
+
+    if not window.win or not vim.api.nvim_win_is_valid(window.win) then
         return nil
     end
 

--- a/plugin/command.lua
+++ b/plugin/command.lua
@@ -36,6 +36,13 @@ vim.keymap.set({'n', 'x', 'v'}, '<Plug>(CommandExecuteSelection)', function()
     end
 end, { desc = 'Execute selected text as command' })
 
+vim.keymap.set({ 'n', 'i' }, '<Plug>(CommandReopenTerminal)', function()
+    local command = load_command()
+    if command then
+        command.reopen_terminal()
+    end
+end, { desc = 'Reopen last terminal' })
+
 -- Create user commands (lazy-loaded)
 vim.api.nvim_create_user_command("CommandExecute", function()
     local command = load_command()
@@ -57,3 +64,10 @@ vim.api.nvim_create_user_command("CommandExecuteSelection", function()
         command.execute_selection()
     end
 end, { range = true })
+
+vim.api.nvim_create_user_command("CommandReopenTerminal", function()
+    local command = load_command()
+    if command then
+        command.reopen_terminal()
+    end
+end, {})


### PR DESCRIPTION
## Summary

- Closing the terminal window (with `q`, `:q`, or any accidental close) no longer destroys the buffer — the session keeps tracking it so output is preserved.
- New `terminal.hide()` / `terminal_act.hide()` closes only the window, keeping the buffer alive.
- New `:CommandReopenTerminal` command (and `<Plug>(CommandReopenTerminal)` mapping) reopens the last hidden terminal buffer in a new split with the same layout options and keymaps restored.
- The stored terminal is replaced the next time a new command is executed.

## Breaking change (minor)

The default `q` keymap in the terminal window now calls `terminal_act.hide` instead of `terminal_act.close`. Users with custom terminal keymaps using `terminal_act.close` are unaffected — `close` still exists and destroys the buffer as before.